### PR TITLE
Convert cyberduck-release-osx to GitHub Actions

### DIFF
--- a/.github/workflows/cyberduck-release-osx.yml
+++ b/.github/workflows/cyberduck-release-osx.yml
@@ -1,0 +1,153 @@
+name: cyberduck-release-osx
+on:
+  workflow_dispatch:
+env:
+  NOTARIZATION_USER: "${{ secrets.29C5E2B5_8D98_474A_9BBD_122D794ED3EB_NOTARIZATION_USER }}"
+  NOTARIZATION_PW: "${{ secrets.29C5E2B5_8D98_474A_9BBD_122D794ED3EB_NOTARIZATION_PW }}"
+  AWS_ACCESS_KEY_DEPLOYMENT: "${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_ACCESS_KEY_DEPLOYMENT }}"
+  AWS_SECRET_KEY_DEPLOYMENT: "${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_SECRET_KEY_DEPLOYMENT }}"
+  RACKSPACE_USER: "${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_USER }}"
+  RACKSPACE_PASSWORD: "${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_PASSWORD }}"
+#   # This item has no matching transformer
+#   org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper:
+#     plugin: config-file-provider@938.ve2b_8a_591c596
+#     managedFiles:
+#     - org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile:
+#         fileId: 0a108231-8dcd-43b5-b8e6-e48e49380247
+#         targetLocation: "$WORKSPACE/www/update/private-ed25519.pem"
+#         replaceTokens: 'false'
+#   # TimestamperBuildWrapper was not converted because the behavior is available by default in GitHub Actions and/or it is not configurable
+#   # This item has no matching transformer
+#         fileId: 5d9d075e-ca4f-4679-ac9b-0846bc8f53f4
+#         targetLocation: "$WORKSPACE/settings.xml"
+#         fileId: 05db0dbd-e0f0-4eb5-881b-524c43e54802
+#         targetLocation: "$WORKSPACE/www/update/private.pem"
+#   com.sic.plugins.kpp.KPPKeychainsBuildWrapper:
+#     plugin: kpp-management-plugin@105.v767485951b_d2
+#     keychainCertificatePairs:
+#     - com.sic.plugins.kpp.model.KPPKeychainCertificatePair:
+#         keychain: macos.keychain
+#         codeSigningIdentity:
+#         varPrefix:
+#     deleteKeychainsAfterBuild: 'true'
+#     overwriteExistingKeychains: 'true'
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - osx
+    steps:
+    - name: clean workspace
+      shell: ruby {0}
+      run: |-
+        require "fileutils"
+        Dir.chdir(ENV["GITHUB_WORKSPACE"]) do
+          paths = Dir.glob(["**/*"])
+          paths -= Dir.glob([".git/**", ".repository/**"])
+          paths.each do |path|
+            File.delete(path) if File.file?(path)
+            FileUtils.rm_rf(path) if File.directory?(path)
+          end
+        end
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: run command
+      shell: bash
+      run: |-
+        /usr/bin/security unlock-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN_PATH }} || true
+        /usr/bin/security set-keychain-settings -u ${{ env.KEYCHAIN_PATH }} || true
+        /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN_PATH }} || true
+        /usr/bin/security find-identity -v -p codesigning ${{ env.KEYCHAIN_PATH }}
+        /usr/bin/security list-keychains -d user -s ${{ env.KEYCHAIN_PATH }}
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: zulu
+        java-version: '1.11'
+        settings-path: "${{ github.workspace }}"
+    - name: Run maven
+      run: 'mvn clean deploy --projects osx,i18n -am --settings $WORKSPACE/settings.xml -DskipTests -D"xcode.configuration=Release" -D"sparkle.feed=" -D"installer.certificate=Developer ID Installer: David Kocher (G69SCX94XU)" -D"codesign.certificate=Developer ID Application: David Kocher (G69SCX94XU)" -D"codesign.arg=--entitlements ${{ github.workspace }}/setup/app/default.entitlements --requirements ${{ github.workspace }}/setup/app/codesign-requirement.bin"'
+    - name: run command
+      shell: bash
+      run: |-
+        cd ${{ github.workspace }}
+        find osx/target/release -name 'Cyberduck-*' -print0 | xargs -0 -I {} -t sh -c 'f="{}"; /usr/local/bin/duck --username ${{ env.RACKSPACE_USER }} --password ${{ env.RACKSPACE_PASSWORD }} --quiet --retry --existing overwrite --region DFW --upload rackspace:/cdn.cyberduck.ch/ "${{ env.f }}"'
+    - name: run command
+      shell: bash
+      run: |-
+        cd ${{ github.workspace }}
+        find osx/target/release -name 'Cyberduck-*' -print0 | xargs -0 -I {} -t sh -c 'f="{}"; /usr/local/bin/duck --username ${{ env.AWS_ACCESS_KEY_DEPLOYMENT }} --password ${{ env.AWS_SECRET_KEY_DEPLOYMENT }} --quiet --retry --existing overwrite --region us-east-1 --upload s3:/release.cyberduck.io/ "${{ env.f }}"'
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3.1.3
+      if: always()
+      with:
+        path: |-
+          osx/target/release/Cyberduck-*
+          !**/*~
+          !**/#*#
+          !**/.#*
+          !**/%*%
+          !**/._*
+          !**/CVS
+          !**/CVS/**
+          !**/.cvsignore
+          !**/SCCS
+          !**/SCCS/**
+          !**/vssver.scc
+          !**/.svn
+          !**/.svn/**
+          !**/.DS_Store
+          !**/.git
+          !**/.git/**
+          !**/.gitattributes
+          !**/.gitignore
+          !**/.gitmodules
+          !**/.hg
+          !**/.hg/**
+          !**/.hgignore
+          !**/.hgsub
+          !**/.hgsubstate
+          !**/.hgtags
+          !**/.bzr
+          !**/.bzr/**
+          !**/.bzrignore
+#     # Fingerprinter was not converted because the behavior is available by default in GitHub Actions and/or it is not configurable
+#     # Mailer plugin was not converted because GitHub Actions will email the actor after failed build and does not support emailing a list of recipients
+    # Ensure parameter if_key_exists is set correctly
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2.6.1
+      with:
+        key: "${{ secrets.VERSION_CYBERDUCK_IO_SSH_KEY }}"
+        name: id_rsa-version_cyberduck_io
+        known_hosts: "${{ secrets.VERSION_CYBERDUCK_IO_KNOWN_HOSTS }}"
+        if_key_exists: fail
+        config: |
+          Host VERSION_CYBERDUCK_IO
+            HostName ${{ secrets.VERSION_CYBERDUCK_IO_HOST_NAME }}
+            User ${{ secrets.VERSION_CYBERDUCK_IO_USER }}
+            IdentityFile ~/.ssh/id_rsa-version_cyberduck_io
+      if: always()
+    - name: setup file transfer file
+      uses: actions/github-script@v7.0.0
+      with:
+        script: |-
+          const fs = require('fs').promises
+          const path = require('path')
+          const patterns = "osx/target/release/changelog.*,!**/*~,!**/#*#,!**/.#*,!**/%*%,!**/._*,!**/CVS,!**/CVS/**,!**/.cvsignore,!**/SCCS,!**/SCCS/**,!**/vssver.scc,!**/.svn,!**/.svn/**,!**/.DS_Store,!**/.git,!**/.git/**,!**/.gitattributes,!**/.gitignore,!**/.gitmodules,!**/.hg,!**/.hg/**,!**/.hgignore,!**/.hgsub,!**/.hgsubstate,!**/.hgtags,!**/.bzr,!**/.bzr/**,!**/.bzrignore"
+          const globber = await glob.create(patterns.replace(/,/g, "\n"))
+          const files = []
+          for await (const file of globber.globGenerator()) {
+              if ((await fs.lstat(file)).isDirectory()) continue
+              files.push(path.relative(process.cwd(), file))
+          }
+          fs.writeFile("version_cyberduck_io-transfer.txt", files.join("\n"), (err) => {})
+      if: always()
+    - name: run file transfers
+      run: |-
+        ssh VERSION_CYBERDUCK_IO 'mkdir -p ${{ env.REMOTE_DIRECTORY }}'
+        tar -cvf version_cyberduck_io-transfer.tar --files-from version_cyberduck_io-transfer.txt
+        scp version_cyberduck_io-transfer.tar VERSION_CYBERDUCK_IO:
+        ssh VERSION_CYBERDUCK_IO 'tar -xvf version_cyberduck_io-transfer.tar -C ${{ env.REMOTE_DIRECTORY }} && rm version_cyberduck_io-transfer.tar'
+      env:
+        REMOTE_DIRECTORY: UPDATE_ME
+      if: always()


### PR DESCRIPTION
Pipeline migrated from [Jenkins](https://ci.iterate.ch/job/cyberduck-release-osx) :tada:

## Manual steps

Perform the following steps to complete the migration:

### cyberduck-release-osx
- [ ] Ensure a runner with the following labels exists: osx
- [ ] Ensure: Java version in actions/setup-java is correct since we couldn't determine the version in use.
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_HOST_NAME }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_USER }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_SSH_KEY }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_KNOWN_HOSTS }}`
- [ ] Ensure environment variable is updated: `REMOTE_DIRECTORY`
- [ ] Ensure secret is available: `${{ secrets.29C5E2B5_8D98_474A_9BBD_122D794ED3EB_NOTARIZATION_USER }}`
- [ ] Ensure secret is available: `${{ secrets.29C5E2B5_8D98_474A_9BBD_122D794ED3EB_NOTARIZATION_PW }}`
- [ ] Ensure secret is available: `${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_ACCESS_KEY_DEPLOYMENT }}`
- [ ] Ensure secret is available: `${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_SECRET_KEY_DEPLOYMENT }}`
- [ ] Ensure secret is available: `${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_USER }}`
- [ ] Ensure secret is available: `${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_PASSWORD }}`