### PR TITLE
Convert cyberduck-beta-windows to GitHub Actions

### DIFF
--- a/.github/workflows/cyberduck-beta-windows.yml
+++ b/.github/workflows/cyberduck-beta-windows.yml
@@ -1,0 +1,125 @@
+name: cyberduck-beta-windows
+on:
+  workflow_dispatch:
+env:
+  AWS_ACCESS_KEY_DEPLOYMENT: "${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_ACCESS_KEY_DEPLOYMENT }}"
+  AWS_SECRET_KEY_DEPLOYMENT: "${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_SECRET_KEY_DEPLOYMENT }}"
+  RACKSPACE_USER: "${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_USER }}"
+  RACKSPACE_PASSWORD: "${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_PASSWORD }}"
+#   # This item has no matching transformer
+#   org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper:
+#     plugin: config-file-provider@3.8.2
+#     managedFiles:
+#     - org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile:
+#         fileId: 05db0dbd-e0f0-4eb5-881b-524c43e54802
+#         targetLocation: "$WORKSPACE/www/update/private.pem"
+#         replaceTokens: 'false'
+#   # TimestamperBuildWrapper was not converted because the behavior is available by default in GitHub Actions and/or it is not configurable
+#         fileId: 5d9d075e-ca4f-4679-ac9b-0846bc8f53f4
+#         targetLocation: "$WORKSPACE/settings.xml"
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - windows
+    steps:
+    - name: clean workspace
+      shell: ruby {0}
+      run: |-
+        require "fileutils"
+        Dir.chdir(ENV["GITHUB_WORKSPACE"]) do
+          paths = Dir.glob(["**/*"])
+          paths -= Dir.glob([".git/**", ".repository/**"])
+          paths.each do |path|
+            File.delete(path) if File.file?(path)
+            FileUtils.rm_rf(path) if File.directory?(path)
+          end
+        end
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: zulu
+        java-version: '1.11'
+        settings-path: "${{ github.workspace }}"
+    - name: Run maven
+      run: mvn clean deploy --projects windows --also-make --update-snapshots --settings $WORKSPACE/settings.xml -DskipTests -D"sparkle.feed=beta"
+    - name: run batch command
+      shell: cmd
+      run: FOR %%c in ("%WORKSPACE%\windows\target\Release\Cyberduck-*") DO "C:\Program Files\Cyberduck CLI\duck.exe" --upload rackspace:/beta.cyberduck.io/ "%%c" --username %RACKSPACE_USER% --password %RACKSPACE_PASSWORD% --retry --quiet --existing overwrite --region IAD
+    - name: run batch command
+      shell: cmd
+      run: FOR %%c in ("%WORKSPACE%\windows\target\release\Cyberduck-*") DO "C:\Program Files\Cyberduck CLI\duck.exe" --upload s3:/beta.cyberduck.io/ "%%c" --username %AWS_ACCESS_KEY_DEPLOYMENT% --password %AWS_SECRET_KEY_DEPLOYMENT% --retry --quiet --existing skip --region us-east-1
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        path: |-
+          windows\target\Release\*.exe
+          windows\target\Release\*.msi
+          windows\target\Release\*.appx
+          !**/*~
+          !**/#*#
+          !**/.#*
+          !**/%*%
+          !**/._*
+          !**/CVS
+          !**/CVS/**
+          !**/.cvsignore
+          !**/SCCS
+          !**/SCCS/**
+          !**/vssver.scc
+          !**/.svn
+          !**/.svn/**
+          !**/.DS_Store
+          !**/.git
+          !**/.git/**
+          !**/.gitattributes
+          !**/.gitignore
+          !**/.gitmodules
+          !**/.hg
+          !**/.hg/**
+          !**/.hgignore
+          !**/.hgsub
+          !**/.hgsubstate
+          !**/.hgtags
+          !**/.bzr
+          !**/.bzr/**
+          !**/.bzrignore
+#     # Mailer plugin was not converted because GitHub Actions will email the actor after failed build and does not support emailing a list of recipients
+    # Ensure parameter if_key_exists is set correctly
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2.6.1
+      with:
+        key: "${{ secrets.VERSION_CYBERDUCK_IO_SSH_KEY }}"
+        name: id_rsa-version_cyberduck_io
+        known_hosts: "${{ secrets.VERSION_CYBERDUCK_IO_KNOWN_HOSTS }}"
+        if_key_exists: fail
+        config: |
+          Host VERSION_CYBERDUCK_IO
+            HostName ${{ secrets.VERSION_CYBERDUCK_IO_HOST_NAME }}
+            User ${{ secrets.VERSION_CYBERDUCK_IO_USER }}
+            IdentityFile ~/.ssh/id_rsa-version_cyberduck_io
+      if: always()
+    - name: setup file transfer file
+      uses: actions/github-script@v7.0.0
+      with:
+        script: |-
+          const fs = require('fs').promises
+          const path = require('path')
+          const patterns = "windows/target/update/changelog.*,!**/*~,!**/#*#,!**/.#*,!**/%*%,!**/._*,!**/CVS,!**/CVS/**,!**/.cvsignore,!**/SCCS,!**/SCCS/**,!**/vssver.scc,!**/.svn,!**/.svn/**,!**/.DS_Store,!**/.git,!**/.git/**,!**/.gitattributes,!**/.gitignore,!**/.gitmodules,!**/.hg,!**/.hg/**,!**/.hgignore,!**/.hgsub,!**/.hgsubstate,!**/.hgtags,!**/.bzr,!**/.bzr/**,!**/.bzrignore"
+          const globber = await glob.create(patterns.replace(/,/g, "\n"))
+          const files = []
+          for await (const file of globber.globGenerator()) {
+              if ((await fs.lstat(file)).isDirectory()) continue
+              files.push(path.relative(process.cwd(), file))
+          }
+          fs.writeFile("version_cyberduck_io-transfer.txt", files.join("\n"), (err) => {})
+      if: always()
+    - name: run file transfers
+      run: |-
+        ssh VERSION_CYBERDUCK_IO 'mkdir -p windows/beta'
+        tar -cvf version_cyberduck_io-transfer.tar --files-from version_cyberduck_io-transfer.txt
+        scp version_cyberduck_io-transfer.tar VERSION_CYBERDUCK_IO:
+        ssh VERSION_CYBERDUCK_IO 'tar -xvf version_cyberduck_io-transfer.tar -C windows/beta && rm version_cyberduck_io-transfer.tar'
+      if: always()


### PR DESCRIPTION
Pipeline migrated from [Jenkins](https://ci.iterate.ch/job/cyberduck-beta-windows) :tada:

## Manual steps

Perform the following steps to complete the migration:

### cyberduck-beta-windows
- [ ] Ensure a runner with the following labels exists: windows
- [ ] Ensure: Java version in actions/setup-java is correct since we couldn't determine the version in use.
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_HOST_NAME }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_USER }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_SSH_KEY }}`
- [ ] Ensure secret is available: `${{ secrets.VERSION_CYBERDUCK_IO_KNOWN_HOSTS }}`
- [ ] Ensure secret is available: `${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_ACCESS_KEY_DEPLOYMENT }}`
- [ ] Ensure secret is available: `${{ secrets.52D57BB0_E2E1_46D3_A431_13B5E39E1334_AWS_SECRET_KEY_DEPLOYMENT }}`
- [ ] Ensure secret is available: `${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_USER }}`
- [ ] Ensure secret is available: `${{ secrets.9FBE3DFE_89F3_4A37_BD20_42C301B6EB68_RACKSPACE_PASSWORD }}`